### PR TITLE
UTF-8 support.

### DIFF
--- a/framework-ega-infra/src/main/java/com/ibm/watson/app/common/services/nlclassifier/model/NLClassifierTrainingData.java
+++ b/framework-ega-infra/src/main/java/com/ibm/watson/app/common/services/nlclassifier/model/NLClassifierTrainingData.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -58,7 +59,7 @@ public class NLClassifierTrainingData {
 	}
 
 	public static NLClassifierTrainingData fromStream(InputStream stream) throws IOException {
-		try(Reader reader = new InputStreamReader(stream)) {
+		try(Reader reader = new InputStreamReader(stream, StandardCharsets.UTF_8)) {
 			return gson.fromJson(reader, NLClassifierTrainingData.class);
 		}
 	}


### PR DESCRIPTION
Please pull my modification to support UTF-8 encoding for the training data. Without this fix, Japanese does not work.