### PR TITLE
Use jax-rs 1.1 library rather than 2.0

### DIFF
--- a/framework-ega-test/pom.xml
+++ b/framework-ega-test/pom.xml
@@ -25,8 +25,8 @@
   <dependencies>
 	<dependency>
 		<groupId>javax.ws.rs</groupId>
-		<artifactId>javax.ws.rs-api</artifactId>
-		<version>2.0.1</version>
+		<artifactId>jsr311-api</artifactId>
+		<version>1.1.1</version>
 	</dependency>
 
     <dependency>


### PR DESCRIPTION
Fixes RTC issue [95816](https://nsjazz.raleigh.ibm.com:8050/ccm/web/projects/Watson%20Core%20Platform%2C%20Tooling%2C%20and%20Products#action=com.ibm.team.workitem.viewWorkItem&id=95816).

The 2.0 jax-rs dependency seems to cause `<installed facet="jst.jaxrs" version="2.0"/>` in .settings/org.eclipse.wst.common.project.facet.core.xml.  Then this results in an error when trying to deploy the application to a Liberty server in Eclipse.

This change sets the jaxrs facet version to 1.1.

Ready for review.